### PR TITLE
Upgrades for pmg/queue 4.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,7 @@ php:
     - 7.1
 
 notifications:
-    email:
-        recipients:
-            - tech@pmg.com
-    on_success: change
-    on_failure: always
+    email: false
 
 before_install:
     - curl -L https://github.com/kr/beanstalkd/archive/v1.10.tar.gz | tar -xz -C /tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-    - 5.6
     - 7.0
+    - 7.1
 
 notifications:
     email:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: test testnocov examples
 
 testnocov:
-	php vendor/bin/phpunit
+	php vendor/bin/phpunit -v
 
 test:
-	php vendor/bin/phpunit --coverage-text
+	php vendor/bin/phpunit -v --coverage-text
 
 examples:
 	php examples/pheanstalk.php

--- a/composer.json
+++ b/composer.json
@@ -6,14 +6,13 @@
         { "name": "Christopher Davis", "email": "chris@pmg.com" }
     ],
     "require": {
-        "php": "~5.6|~7.0",
-        "pmg/queue": "~3.0",
+        "php": "~7.0",
+        "pmg/queue": "~4.0@dev",
         "pda/pheanstalk": "~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0"
+        "phpunit/phpunit": "~6.0"
     },
-    "minimum-stability": "dev",
     "autoload": {
         "psr-4": {
             "PMG\\Queue\\Driver\\": "src/"

--- a/examples/pheanstalk.php
+++ b/examples/pheanstalk.php
@@ -18,7 +18,7 @@ if (PHP_VERSION_ID >= 70000) {
         Queue\SimpleMessage::class,
     ], Queue\Driver\PheanstalkDriver::allowedClasses());
 }
-$serializer = new Queue\Serializer\NativeSerializer('SuperSecretKey', $allowedClasses);
+$serializer = Queue\Serializer\NativeSerializer::fromSigningKey('SuperSecretKey', $allowedClasses);
 $driver = new Queue\Driver\PheanstalkDriver($conn, $serializer);
 
 $router = new Queue\Router\MappingRouter([

--- a/test/PheanstalkTestCase.php
+++ b/test/PheanstalkTestCase.php
@@ -12,7 +12,7 @@
 
 namespace PMG\Queue\Driver;
 
-abstract class PheanstalkTestCase extends \PHPUnit_Framework_TestCase
+abstract class PheanstalkTestCase extends \PHPUnit\Framework\TestCase
 {
     protected static function createConnection()
     {

--- a/test/UnhappyPheanstalkDriverTest.php
+++ b/test/UnhappyPheanstalkDriverTest.php
@@ -90,10 +90,18 @@ class UnhappyPheanstalkDriverTest extends PheanstalkTestCase
         $this->driver->fail('q', $this->env);
     }
 
+    /**
+     * @expectedException PMG\Queue\Driver\Pheanstalk\PheanstalkError
+     */
+    public function testReleaseErrorsWhenTheUnerlyingConnectionErrors()
+    {
+        $this->driver->release('q', $this->env);
+    }
+
     protected function setUp()
     {
         $this->conn = new \Pheanstalk\Pheanstalk('localhost', 65000);
-        $this->driver = new PheanstalkDriver($this->conn, new NativeSerializer('supersecret'));
+        $this->driver = new PheanstalkDriver($this->conn, NativeSerializer::fromSigningKey('supersecret'));
         $this->env = new PheanstalkEnvelope(
             new Job(123, 't'),
             new DefaultEnvelope(new SimpleMessage('t'))


### PR DESCRIPTION
Including the new, stricted type declarations as well was `PheanstalkDriver::release`.