### PR TITLE
Correctly Implement PheanstalkEnvelope::retry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,6 @@ test:
 
 examples:
 	php examples/pheanstalk.php
+	php examples/retrying.php
 
 travis: test examples

--- a/examples/retrying.php
+++ b/examples/retrying.php
@@ -1,0 +1,54 @@
+<?php
+
+use PMG\Queue;
+use Pheanstalk\Pheanstalk;
+use Pheanstalk\Contract\PheanstalkInterface;
+
+require __DIR__.'/../vendor/autoload.php';
+require __DIR__.'/StreamLogger.php';
+
+$conn = Pheanstalk::create('localhost');
+$tubes = $conn->listTubes();
+do {
+    $queueName = uniqid('example_');
+} while (in_array($queueName, $tubes, true));
+
+// native serializer supports allowed classes in PHP 7+
+$allowedClasses = null;
+if (PHP_VERSION_ID >= 70000) {
+    $allowedClasses = array_merge([
+        Queue\SimpleMessage::class,
+    ], Queue\Driver\PheanstalkDriver::allowedClasses());
+}
+$serializer = Queue\Serializer\NativeSerializer::fromSigningKey('SuperSecretKey', $allowedClasses);
+$driver = new Queue\Driver\PheanstalkDriver($conn, $serializer, [
+    'retry-priority' => 0, // most urgent
+]);
+
+$router = new Queue\Router\MappingRouter([
+    'TestMessage'   => $queueName,
+    'MustStop'      => $queueName,
+]);
+
+$handler = new Queue\Handler\CallableHandler(function (Queue\Message $msg) {
+    $name = $msg->getName();
+    if ('MustStop' === $name) {
+        throw new Queue\Exception\SimpleMustStop();
+    }
+
+    throw new \Exception('errors get retried');
+});
+
+$producer = new Queue\DefaultProducer($driver, $router);
+
+$consumer = new Queue\DefaultConsumer(
+    $driver,
+    $handler,
+    new Queue\Retry\LimitedSpec(3),
+    new StreamLogger()
+);
+
+$producer->send(new Queue\SimpleMessage('TestMessage'));
+$producer->send(new Queue\SimpleMessage('MustStop'));
+
+exit($consumer->run($queueName));

--- a/src/Pheanstalk/PheanstalkEnvelope.php
+++ b/src/Pheanstalk/PheanstalkEnvelope.php
@@ -59,11 +59,13 @@ final class PheanstalkEnvelope implements Envelope
 
     /**
      * {@inheritdoc}
-     * Returns a clone of the wrapped envelope, not itself.
      */
     public function retry(int $delay=0) : Envelope
     {
-        return $this->wrapped->retry($delay);
+        $out = clone $this;
+        $out->wrapped = $this->wrapped->retry($delay);
+
+        return $out;
     }
 
     /**


### PR DESCRIPTION
It needs to return a `PheanstalkEnvelope` so the driver can continue to
work. Otherwise all retries from the consumer will fail.

Also add a `retrying` example as an acceptance/end-to-end test to verify
this works as expected.