### PR TITLE
Don't Serialize the Pheanstalk Envelope

### DIFF
--- a/src/Pheanstalk/BuryFailureStrategy.php
+++ b/src/Pheanstalk/BuryFailureStrategy.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * This file is part of pmg/queue-pheanstalk
  *

--- a/src/Pheanstalk/DeleteFailureStrategy.php
+++ b/src/Pheanstalk/DeleteFailureStrategy.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * This file is part of pmg/queue-pheanstalk
  *

--- a/src/Pheanstalk/FailureStrategy.php
+++ b/src/Pheanstalk/FailureStrategy.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * This file is part of pmg/queue-pheanstalk
  *

--- a/src/Pheanstalk/PheanstalkEnvelope.php
+++ b/src/Pheanstalk/PheanstalkEnvelope.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * This file is part of pmg/queue-pheanstalk
  *
@@ -84,5 +84,10 @@ final class PheanstalkEnvelope implements Envelope
     public function getJobId()
     {
         return $this->getJob()->getId();
+    }
+
+    public function getWrappedEnvelope() : Envelope
+    {
+        return $this->wrapped;
     }
 }

--- a/src/Pheanstalk/PheanstalkError.php
+++ b/src/Pheanstalk/PheanstalkError.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * This file is part of pmg/queue-pheanstalk
  *


### PR DESCRIPTION
There were some bugs in the retry code that caused us to continually
re-serialize a pheanstalk envelope. Which blew up our serialized job
size.