### PR TITLE
Use an Options Object Instead of an Array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 5.1.0
+
+## Added
+
+- `PMG\Queue\Driver\Pheanstalk\PheanstalkOptions` interface as added along with
+  an implementation backed by an array (`ArrayOptions`). This should allow
+  end-users to change message options (things like priority, etc) based on
+  incoming messages.
+
+## Deprecated
+
+- Passing an array of options to `PheanstalkDriver`'s constructor is deprecated,
+  use a `PheanstalkOptions` implementation instead (probably `ArrayOptions`)
+- Passing null or an integer to `BuryFailureStrategy` is deprecated, pass a
+  `PheanstalkOptions` implementation instead.
+
 ## 5.0.0
 
 **Important Note:** we're skipping v4.X because I'm tired of trying to figure

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",
+        "symfony/phpunit-bridge": "^4.4",
         "pmg/queue": "^5.0@beta"
     },
     "autoload": {

--- a/src/Pheanstalk/ArrayOptions.php
+++ b/src/Pheanstalk/ArrayOptions.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of pmg/queue-pheanstalk
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue\Driver\Pheanstalk;
+
+use Pheanstalk\Contract\PheanstalkInterface;
+
+/**
+ * An options implementation backed by an array passed to the constructor.
+ * This mimics the behavior that already existed in 5.0
+ */
+final class ArrayOptions implements PheanstalkOptions
+{
+    /**
+     * @var array
+     */
+    private $options;
+
+    public function __construct(array $options)
+    {
+        $this->options = array_replace([
+            self::PRIORITY => PheanstalkInterface::DEFAULT_PRIORITY,
+            self::DELAY => PheanstalkInterface::DEFAULT_DELAY,
+            self::TTR => PheanstalkInterface::DEFAULT_TTR,
+            self::RETRY_PRIORITY => PheanstalkInterface::DEFAULT_PRIORITY,
+            self::RETRY_TTR => PheanstalkInterface::DEFAULT_TTR,
+            self::FAIL_PRIORITY => PheanstalkInterface::DEFAULT_PRIORITY,
+            self::RELEASE_PRIORITY => PheanstalkInterface::DEFAULT_PRIORITY,
+            self::RELEASE_DELAY => PheanstalkInterface::DEFAULT_DELAY,
+            self::RESERVE_TIMEOUT => 10,
+        ], $options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMessageOption(string $optionName, object $message)
+    {
+        return $this->get($optionName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getGlobalOption(string $optionName)
+    {
+        return $this->get($optionName);
+    }
+
+    private function get(string $optionName)
+    {
+        if (!isset($this->options[$optionName])) {
+            throw MissingOption::fromName($optionName);
+        }
+
+        return $this->options[$optionName];
+    }
+}

--- a/src/Pheanstalk/MissingOption.php
+++ b/src/Pheanstalk/MissingOption.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of pmg/queue-pheanstalk
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue\Driver\Pheanstalk;
+
+use PMG\Queue\Exception\DriverError;
+
+/**
+ * Thrown when a PheanstalkOptions implementation can't find the option that
+ * was asked of it.
+ */
+final class MissingOption extends \RuntimeException implements DriverError
+{
+    public static function fromName(string $optionName) : self
+    {
+        return new self(sprintf('missing option "%s"', $optionName));
+    }
+}

--- a/src/Pheanstalk/PheanstalkOptions.php
+++ b/src/Pheanstalk/PheanstalkOptions.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of pmg/queue-pheanstalk
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue\Driver\Pheanstalk;
+
+/**
+ * Abstraction around getting options for a given message -- this can change
+ * how the message goes into the queue (eg priority, delay, etc)
+ */
+interface PheanstalkOptions
+{
+    const PRIORITY = 'priority';
+    const DELAY = 'delay';
+    const TTR = 'ttr';
+    const RETRY_PRIORITY = 'retry-priority';
+    const RETRY_TTR = 'retry-ttr';
+    const FAIL_PRIORITY = 'fail-priority';
+    const RELEASE_PRIORITY = 'release-priority';
+    const RELEASE_DELAY = 'release-delay';
+    const RESERVE_TIMEOUT = 'reserve-timeout';
+
+    /**
+     * Get the $optionName for the message.
+     *
+     * @param $optionName the option to retrieve
+     * @param $message the message for which the option is being retrieved, may be
+     *        null if retrieving an option for which there would not be a message
+     * @throws MissingOption if the $optionName is not available
+     * @return mixed but probably an int
+     */
+    public function getMessageOption(string $optionName, object $message);
+
+    /**
+     * Get a global $optionName
+     *
+     * @param $optionName the option to retrieve
+     * @throws MissingOption if the $optionName is not available
+     * @return mixed but probably an int
+     */
+    public function getGlobalOption(string $optionName);
+}

--- a/test/HappyPheanstalkDriverTest.php
+++ b/test/HappyPheanstalkDriverTest.php
@@ -113,7 +113,7 @@ class HappyPheanstalkDriverTest extends PheanstalkTestCase
     public function testFailWithADeleteFailureStrategyRemovesTheJob()
     {
         $driver = new PheanstalkDriver($this->conn, $this->serializer, new ArrayOptions([
-            'reserve-timeout' => 1,
+            ArrayOptions::RESERVE_TIMEOUT => 1,
         ]), new Pheanstalk\DeleteFailureStrategy());
         $tube = $this->randomTube();
 

--- a/test/HappyPheanstalkDriverTest.php
+++ b/test/HappyPheanstalkDriverTest.php
@@ -16,6 +16,7 @@ use Pheanstalk\Exception\ServerException;
 use PMG\Queue\SimpleMessage;
 use PMG\Queue\DefaultEnvelope;
 use PMG\Queue\Serializer\NativeSerializer;
+use PMG\Queue\Driver\Pheanstalk\ArrayOptions;
 use PMG\Queue\Driver\Pheanstalk\PheanstalkEnvelope;
 use PMG\Queue\Driver\Pheanstalk\PheanstalkError;
 
@@ -111,9 +112,9 @@ class HappyPheanstalkDriverTest extends PheanstalkTestCase
 
     public function testFailWithADeleteFailureStrategyRemovesTheJob()
     {
-        $driver = new PheanstalkDriver($this->conn, $this->serializer, [
+        $driver = new PheanstalkDriver($this->conn, $this->serializer, new ArrayOptions([
             'reserve-timeout' => 1,
-        ], new Pheanstalk\DeleteFailureStrategy());
+        ]), new Pheanstalk\DeleteFailureStrategy());
         $tube = $this->randomTube();
 
         $env = $driver->enqueue($tube, new SimpleMessage('TestMessage'));
@@ -150,9 +151,9 @@ class HappyPheanstalkDriverTest extends PheanstalkTestCase
     {
         $this->conn = self::createConnection();
         $this->serializer = NativeSerializer::fromSigningKey('supersecret');
-        $this->driver = new PheanstalkDriver($this->conn, $this->serializer, [
-            'reserve-timeout'   => 1,
-        ]);
+        $this->driver = new PheanstalkDriver($this->conn, $this->serializer, new ArrayOptions([
+            ArrayOptions::RESERVE_TIMEOUT => 1,
+        ]));
 
         try {
             $this->seenTubes = array_fill_keys($this->conn->listTubes(), true);

--- a/test/Pheanstalk/ArrayOptionsTest.php
+++ b/test/Pheanstalk/ArrayOptionsTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This file is part of pmg/queue-pheanstalk
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue\Driver\Pheanstalk;
+
+use PMG\Queue\Driver\PheanstalkTestCase;
+
+class ArrayOptionsTest extends PheanstalkTestCase
+{
+    private $options;
+
+    public function testGetMessageOptionErrorsWhenGivenAnInvalidOptionName()
+    {
+        $this->expectException(MissingOption::class);
+
+        $this->options->getMessageOption(__METHOD__, new class() {});
+    }
+
+    public function testGetMessageOptionReturnsOptionValueWhenOptionExists()
+    {
+        $option = $this->options->getMessageOption('test', new class() {});
+
+        $this->assertSame(123, $option);
+    }
+
+    public function testGetGlobalOptionErrorsWhenGivenAnInvalidOptionName()
+    {
+        $this->expectException(MissingOption::class);
+
+        $this->options->getGlobalOption(__METHOD__);
+    }
+
+    public function testGetGlobalOptionReturnsOptionValueWhenOptionExists()
+    {
+        $option = $this->options->getGlobalOption('test');
+
+        $this->assertSame(123, $option);
+    }
+
+    protected function setUp() : void
+    {
+        $this->options = new ArrayOptions([
+            'test' => 123,
+        ]);
+    }
+}

--- a/test/Pheanstalk/BuryFailureStrategyTest.php
+++ b/test/Pheanstalk/BuryFailureStrategyTest.php
@@ -22,7 +22,9 @@ class BuryFailureStrategyTest extends PheanstalkTestCase
 {
     public function testFailBuriesTheGivenPheanstalkJob()
     {
-        $s = new BuryFailureStrategy(20);
+        $s = new BuryFailureStrategy(new ArrayOptions([
+            PheanstalkOptions::FAIL_PRIORITY => 20,
+        ]));
         $job = new Job(123, 'ignored');
         $env = new PheanstalkEnvelope($job, new DefaultEnvelope(new SimpleMessage('ignored')));
         $conn = $this->createMock(PheanstalkInterface::class);
@@ -31,5 +33,37 @@ class BuryFailureStrategyTest extends PheanstalkTestCase
             ->with($job, 20);
 
         $s->fail($conn, $env);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testBuryStrategyCanStillBeCreatedWithIntegerArgument()
+    {
+        $strategy = new BuryFailureStrategy(20);
+        $job = new Job(123, 'ignored');
+        $env = new PheanstalkEnvelope($job, new DefaultEnvelope(new SimpleMessage('ignored')));
+        $conn = $this->createMock(PheanstalkInterface::class);
+        $conn->expects($this->once())
+            ->method('bury')
+            ->with($job, 20);
+
+        $strategy->fail($conn, $env);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testBuryStrategyCanStillBeCreatedWithNullArgument()
+    {
+        $strategy = new BuryFailureStrategy(null);
+        $job = new Job(123, 'ignored');
+        $env = new PheanstalkEnvelope($job, new DefaultEnvelope(new SimpleMessage('ignored')));
+        $conn = $this->createMock(PheanstalkInterface::class);
+        $conn->expects($this->once())
+            ->method('bury')
+            ->with($job, PheanstalkInterface::DEFAULT_PRIORITY);
+
+        $strategy->fail($conn, $env);
     }
 }


### PR DESCRIPTION
The goal is to let end users implement the `PheanstalkOptions` interface and have some custom options based on the messages.

My immediate use case here is to let messages that are going in as the result of manual actions get a higher priority than automated messages.